### PR TITLE
Update pydantic dependency to version >=2.5.2, <3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ keywords = [
 
 [tool.poetry.dependencies]
 aenum = ">=3.1.11"
-pydantic = ">=2.5.2"
+pydantic = ">=2.5.2, <3"
 python = "^3.8.1"
 python-dateutil = ">=2.8.2"
 urllib3 = ">= 1.25.3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ keywords = [
 
 [tool.poetry.dependencies]
 aenum = ">=3.1.11"
-pydantic = "^1.10.5, <2"
+pydantic = ">=2.5.2"
 python = "^3.8.1"
 python-dateutil = ">=2.8.2"
 urllib3 = ">= 1.25.3"


### PR DESCRIPTION
### Issue

I am in the process of integrating the `gradient` library (version 2.0.6) into my Python backend. However, I've encountered compatibility issues with the current version constraint on the `pydantic` library. The existing constraint is set to `^1.10.5, <2`.

### Proposed Changes

I propose updating the `pydantic` dependency to version `>=2.5.2, <3`. This adjustment is essential for compatibility with the `gradient` library and to ensure a smooth integration process.
