### PR TITLE
Migrate to Pydantic 2

### DIFF
--- a/gradientai/openapi/client/api/blocks_api.py
+++ b/gradientai/openapi/client/api/blocks_api.py
@@ -17,10 +17,10 @@ import re  # noqa: F401
 import io
 import warnings
 
-from pydantic import validate_arguments, ValidationError
+from pydantic.v1 import validate_arguments, ValidationError
 from typing_extensions import Annotated
 
-from pydantic import StrictBytes, StrictStr, constr
+from pydantic.v1 import StrictBytes, StrictStr, constr
 
 from typing import Union
 

--- a/gradientai/openapi/client/api/embeddings_api.py
+++ b/gradientai/openapi/client/api/embeddings_api.py
@@ -17,10 +17,10 @@ import re  # noqa: F401
 import io
 import warnings
 
-from pydantic import validate_arguments, ValidationError
+from pydantic.v1 import validate_arguments, ValidationError
 from typing_extensions import Annotated
 
-from pydantic import StrictStr, constr
+from pydantic.v1 import StrictStr, constr
 
 from gradientai.openapi.client.models.generate_embedding_body_params import GenerateEmbeddingBodyParams
 from gradientai.openapi.client.models.generate_embedding_success import GenerateEmbeddingSuccess

--- a/gradientai/openapi/client/api/files_api.py
+++ b/gradientai/openapi/client/api/files_api.py
@@ -17,10 +17,10 @@ import re  # noqa: F401
 import io
 import warnings
 
-from pydantic import validate_arguments, ValidationError
+from pydantic.v1 import validate_arguments, ValidationError
 from typing_extensions import Annotated
 
-from pydantic import StrictBytes, StrictStr, constr
+from pydantic.v1 import StrictBytes, StrictStr, constr
 
 from typing import Union
 

--- a/gradientai/openapi/client/api/models_api.py
+++ b/gradientai/openapi/client/api/models_api.py
@@ -17,10 +17,10 @@ import re  # noqa: F401
 import io
 import warnings
 
-from pydantic import validate_arguments, ValidationError
+from pydantic.v1 import validate_arguments, ValidationError
 from typing_extensions import Annotated
 
-from pydantic import StrictBool, StrictStr, constr
+from pydantic.v1 import StrictBool, StrictStr, constr
 
 from typing import Any, Dict, Optional
 

--- a/gradientai/openapi/client/api/rag_api.py
+++ b/gradientai/openapi/client/api/rag_api.py
@@ -17,10 +17,10 @@ import re  # noqa: F401
 import io
 import warnings
 
-from pydantic import validate_arguments, ValidationError
+from pydantic.v1 import validate_arguments, ValidationError
 from typing_extensions import Annotated
 
-from pydantic import constr
+from pydantic.v1 import constr
 
 from typing import Any, Dict
 

--- a/gradientai/openapi/client/api_response.py
+++ b/gradientai/openapi/client/api_response.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 from typing import Any, Dict, Optional
-from pydantic import Field, StrictInt, StrictStr
+from pydantic.v1 import Field, StrictInt, StrictStr
 
 class ApiResponse:
     """

--- a/gradientai/openapi/client/models/add_files_to_rag_collection_body_params.py
+++ b/gradientai/openapi/client/models/add_files_to_rag_collection_body_params.py
@@ -20,7 +20,7 @@ import json
 
 
 from typing import Any, Dict, List
-from pydantic import BaseModel, Field, conlist
+from pydantic.v1 import BaseModel, Field, conlist
 from gradientai.openapi.client.models.create_rag_collection_body_params_files_inner import CreateRagCollectionBodyParamsFilesInner
 
 class AddFilesToRagCollectionBodyParams(BaseModel):
@@ -56,7 +56,7 @@ class AddFilesToRagCollectionBodyParams(BaseModel):
                             "additional_properties"
                           },
                           exclude_none=True)
-        # override the default output from pydantic by calling `to_dict()` of each item in files (list)
+        # override the default output from pydantic.v1 by calling `to_dict()` of each item in files (list)
         _items = []
         if self.files:
             for _item in self.files:

--- a/gradientai/openapi/client/models/add_files_to_rag_collection_error.py
+++ b/gradientai/openapi/client/models/add_files_to_rag_collection_error.py
@@ -20,7 +20,7 @@ import json
 
 
 from typing import Any, Dict
-from pydantic import BaseModel, Field, constr
+from pydantic.v1 import BaseModel, Field, constr
 
 class AddFilesToRagCollectionError(BaseModel):
     """

--- a/gradientai/openapi/client/models/analyze_sentiment_body_params.py
+++ b/gradientai/openapi/client/models/analyze_sentiment_body_params.py
@@ -20,7 +20,7 @@ import json
 
 
 from typing import Any, Dict, List, Optional
-from pydantic import BaseModel, Field, conlist, constr
+from pydantic.v1 import BaseModel, Field, conlist, constr
 from gradientai.openapi.client.models.analyze_sentiment_body_params_examples_inner import AnalyzeSentimentBodyParamsExamplesInner
 
 class AnalyzeSentimentBodyParams(BaseModel):
@@ -57,7 +57,7 @@ class AnalyzeSentimentBodyParams(BaseModel):
                             "additional_properties"
                           },
                           exclude_none=True)
-        # override the default output from pydantic by calling `to_dict()` of each item in examples (list)
+        # override the default output from pydantic.v1 by calling `to_dict()` of each item in examples (list)
         _items = []
         if self.examples:
             for _item in self.examples:

--- a/gradientai/openapi/client/models/analyze_sentiment_body_params_examples_inner.py
+++ b/gradientai/openapi/client/models/analyze_sentiment_body_params_examples_inner.py
@@ -20,7 +20,7 @@ import json
 
 
 from typing import Any, Dict
-from pydantic import BaseModel, Field, StrictStr, constr, validator
+from pydantic.v1 import BaseModel, Field, StrictStr, constr, validator
 
 class AnalyzeSentimentBodyParamsExamplesInner(BaseModel):
     """

--- a/gradientai/openapi/client/models/analyze_sentiment_error.py
+++ b/gradientai/openapi/client/models/analyze_sentiment_error.py
@@ -20,7 +20,7 @@ import json
 
 
 from typing import Any, Dict
-from pydantic import BaseModel, Field, constr
+from pydantic.v1 import BaseModel, Field, constr
 
 class AnalyzeSentimentError(BaseModel):
     """

--- a/gradientai/openapi/client/models/analyze_sentiment_success.py
+++ b/gradientai/openapi/client/models/analyze_sentiment_success.py
@@ -20,7 +20,7 @@ import json
 
 
 from typing import Any, Dict
-from pydantic import BaseModel, Field, StrictStr, validator
+from pydantic.v1 import BaseModel, Field, StrictStr, validator
 
 class AnalyzeSentimentSuccess(BaseModel):
     """

--- a/gradientai/openapi/client/models/base_model.py
+++ b/gradientai/openapi/client/models/base_model.py
@@ -20,7 +20,7 @@ import json
 
 
 from typing import Any, Dict, List
-from pydantic import BaseModel, Field, StrictStr, conlist, constr, validator
+from pydantic.v1 import BaseModel, Field, StrictStr, conlist, constr, validator
 
 class BaseModel(BaseModel):
     """

--- a/gradientai/openapi/client/models/complete_model_body_params.py
+++ b/gradientai/openapi/client/models/complete_model_body_params.py
@@ -20,7 +20,7 @@ import json
 
 
 from typing import Any, Dict, Optional, Union
-from pydantic import BaseModel, Field, StrictBool, StrictFloat, StrictInt, conint, constr
+from pydantic.v1 import BaseModel, Field, StrictBool, StrictFloat, StrictInt, conint, constr
 from gradientai.openapi.client.models.complete_model_body_params_guidance import CompleteModelBodyParamsGuidance
 from gradientai.openapi.client.models.complete_model_body_params_rag import CompleteModelBodyParamsRag
 
@@ -64,10 +64,10 @@ class CompleteModelBodyParams(BaseModel):
                             "additional_properties"
                           },
                           exclude_none=True)
-        # override the default output from pydantic by calling `to_dict()` of guidance
+        # override the default output from pydantic.v1 by calling `to_dict()` of guidance
         if self.guidance:
             _dict['guidance'] = self.guidance.to_dict()
-        # override the default output from pydantic by calling `to_dict()` of rag
+        # override the default output from pydantic.v1 by calling `to_dict()` of rag
         if self.rag:
             _dict['rag'] = self.rag.to_dict()
         # puts key-value pairs in additional_properties in the top level

--- a/gradientai/openapi/client/models/complete_model_body_params_guidance.py
+++ b/gradientai/openapi/client/models/complete_model_body_params_guidance.py
@@ -20,7 +20,7 @@ import json
 
 
 from typing import Any, Dict, List
-from pydantic import BaseModel, Field, StrictStr, conlist, constr, validator
+from pydantic.v1 import BaseModel, Field, StrictStr, conlist, constr, validator
 
 class CompleteModelBodyParamsGuidance(BaseModel):
     """

--- a/gradientai/openapi/client/models/complete_model_body_params_rag.py
+++ b/gradientai/openapi/client/models/complete_model_body_params_rag.py
@@ -20,7 +20,7 @@ import json
 
 
 from typing import Any, Dict
-from pydantic import BaseModel, Field, constr
+from pydantic.v1 import BaseModel, Field, constr
 
 class CompleteModelBodyParamsRag(BaseModel):
     """

--- a/gradientai/openapi/client/models/complete_model_error.py
+++ b/gradientai/openapi/client/models/complete_model_error.py
@@ -20,7 +20,7 @@ import pprint
 import re  # noqa: F401
 
 from typing import Any, List, Optional
-from pydantic import BaseModel, Field, StrictStr, ValidationError, validator
+from pydantic.v1 import BaseModel, Field, StrictStr, ValidationError, validator
 from gradientai.openapi.client.models.complete_model_error_one_of import CompleteModelErrorOneOf
 from gradientai.openapi.client.models.complete_model_error_one_of1 import CompleteModelErrorOneOf1
 from gradientai.openapi.client.models.complete_model_error_one_of10 import CompleteModelErrorOneOf10
@@ -33,7 +33,7 @@ from gradientai.openapi.client.models.complete_model_error_one_of7 import Comple
 from gradientai.openapi.client.models.complete_model_error_one_of8 import CompleteModelErrorOneOf8
 from gradientai.openapi.client.models.complete_model_error_one_of9 import CompleteModelErrorOneOf9
 from typing import Any, List
-from pydantic import StrictStr, Field
+from pydantic.v1 import StrictStr, Field
 
 COMPLETEMODELERROR_ONE_OF_SCHEMAS = ["CompleteModelErrorOneOf", "CompleteModelErrorOneOf1", "CompleteModelErrorOneOf10", "CompleteModelErrorOneOf2", "CompleteModelErrorOneOf3", "CompleteModelErrorOneOf4", "CompleteModelErrorOneOf5", "CompleteModelErrorOneOf6", "CompleteModelErrorOneOf7", "CompleteModelErrorOneOf8", "CompleteModelErrorOneOf9"]
 

--- a/gradientai/openapi/client/models/complete_model_error_one_of.py
+++ b/gradientai/openapi/client/models/complete_model_error_one_of.py
@@ -20,7 +20,7 @@ import json
 
 
 from typing import Any, Dict
-from pydantic import BaseModel, Field, StrictStr, constr, validator
+from pydantic.v1 import BaseModel, Field, StrictStr, constr, validator
 from gradientai.openapi.client.models.complete_model_error_one_of_payload import CompleteModelErrorOneOfPayload
 
 class CompleteModelErrorOneOf(BaseModel):
@@ -65,7 +65,7 @@ class CompleteModelErrorOneOf(BaseModel):
                             "additional_properties"
                           },
                           exclude_none=True)
-        # override the default output from pydantic by calling `to_dict()` of payload
+        # override the default output from pydantic.v1 by calling `to_dict()` of payload
         if self.payload:
             _dict['payload'] = self.payload.to_dict()
         # puts key-value pairs in additional_properties in the top level

--- a/gradientai/openapi/client/models/complete_model_error_one_of1.py
+++ b/gradientai/openapi/client/models/complete_model_error_one_of1.py
@@ -20,7 +20,7 @@ import json
 
 
 from typing import Any, Dict
-from pydantic import BaseModel, Field, StrictStr, constr, validator
+from pydantic.v1 import BaseModel, Field, StrictStr, constr, validator
 from gradientai.openapi.client.models.complete_model_error_one_of1_payload import CompleteModelErrorOneOf1Payload
 
 class CompleteModelErrorOneOf1(BaseModel):
@@ -65,7 +65,7 @@ class CompleteModelErrorOneOf1(BaseModel):
                             "additional_properties"
                           },
                           exclude_none=True)
-        # override the default output from pydantic by calling `to_dict()` of payload
+        # override the default output from pydantic.v1 by calling `to_dict()` of payload
         if self.payload:
             _dict['payload'] = self.payload.to_dict()
         # puts key-value pairs in additional_properties in the top level

--- a/gradientai/openapi/client/models/complete_model_error_one_of10.py
+++ b/gradientai/openapi/client/models/complete_model_error_one_of10.py
@@ -20,7 +20,7 @@ import json
 
 
 from typing import Any, Dict
-from pydantic import BaseModel, Field, StrictStr, constr, validator
+from pydantic.v1 import BaseModel, Field, StrictStr, constr, validator
 
 class CompleteModelErrorOneOf10(BaseModel):
     """

--- a/gradientai/openapi/client/models/complete_model_error_one_of1_payload.py
+++ b/gradientai/openapi/client/models/complete_model_error_one_of1_payload.py
@@ -20,7 +20,7 @@ import json
 
 
 from typing import Any, Dict, Optional
-from pydantic import BaseModel, Field
+from pydantic.v1 import BaseModel, Field
 
 class CompleteModelErrorOneOf1Payload(BaseModel):
     """

--- a/gradientai/openapi/client/models/complete_model_error_one_of2.py
+++ b/gradientai/openapi/client/models/complete_model_error_one_of2.py
@@ -20,7 +20,7 @@ import json
 
 
 from typing import Any, Dict
-from pydantic import BaseModel, Field, StrictStr, constr, validator
+from pydantic.v1 import BaseModel, Field, StrictStr, constr, validator
 from gradientai.openapi.client.models.complete_model_error_one_of1_payload import CompleteModelErrorOneOf1Payload
 
 class CompleteModelErrorOneOf2(BaseModel):
@@ -65,7 +65,7 @@ class CompleteModelErrorOneOf2(BaseModel):
                             "additional_properties"
                           },
                           exclude_none=True)
-        # override the default output from pydantic by calling `to_dict()` of payload
+        # override the default output from pydantic.v1 by calling `to_dict()` of payload
         if self.payload:
             _dict['payload'] = self.payload.to_dict()
         # puts key-value pairs in additional_properties in the top level

--- a/gradientai/openapi/client/models/complete_model_error_one_of3.py
+++ b/gradientai/openapi/client/models/complete_model_error_one_of3.py
@@ -20,7 +20,7 @@ import json
 
 
 from typing import Any, Dict
-from pydantic import BaseModel, Field, StrictStr, constr, validator
+from pydantic.v1 import BaseModel, Field, StrictStr, constr, validator
 
 class CompleteModelErrorOneOf3(BaseModel):
     """

--- a/gradientai/openapi/client/models/complete_model_error_one_of4.py
+++ b/gradientai/openapi/client/models/complete_model_error_one_of4.py
@@ -20,7 +20,7 @@ import json
 
 
 from typing import Any, Dict
-from pydantic import BaseModel, Field, StrictStr, constr, validator
+from pydantic.v1 import BaseModel, Field, StrictStr, constr, validator
 
 class CompleteModelErrorOneOf4(BaseModel):
     """

--- a/gradientai/openapi/client/models/complete_model_error_one_of5.py
+++ b/gradientai/openapi/client/models/complete_model_error_one_of5.py
@@ -20,7 +20,7 @@ import json
 
 
 from typing import Any, Dict
-from pydantic import BaseModel, Field, StrictStr, constr, validator
+from pydantic.v1 import BaseModel, Field, StrictStr, constr, validator
 
 class CompleteModelErrorOneOf5(BaseModel):
     """

--- a/gradientai/openapi/client/models/complete_model_error_one_of6.py
+++ b/gradientai/openapi/client/models/complete_model_error_one_of6.py
@@ -20,7 +20,7 @@ import json
 
 
 from typing import Any, Dict
-from pydantic import BaseModel, Field, StrictStr, constr, validator
+from pydantic.v1 import BaseModel, Field, StrictStr, constr, validator
 
 class CompleteModelErrorOneOf6(BaseModel):
     """

--- a/gradientai/openapi/client/models/complete_model_error_one_of7.py
+++ b/gradientai/openapi/client/models/complete_model_error_one_of7.py
@@ -20,7 +20,7 @@ import json
 
 
 from typing import Any, Dict
-from pydantic import BaseModel, Field, StrictStr, constr, validator
+from pydantic.v1 import BaseModel, Field, StrictStr, constr, validator
 
 class CompleteModelErrorOneOf7(BaseModel):
     """

--- a/gradientai/openapi/client/models/complete_model_error_one_of8.py
+++ b/gradientai/openapi/client/models/complete_model_error_one_of8.py
@@ -20,7 +20,7 @@ import json
 
 
 from typing import Any, Dict
-from pydantic import BaseModel, Field, StrictStr, constr, validator
+from pydantic.v1 import BaseModel, Field, StrictStr, constr, validator
 
 class CompleteModelErrorOneOf8(BaseModel):
     """

--- a/gradientai/openapi/client/models/complete_model_error_one_of9.py
+++ b/gradientai/openapi/client/models/complete_model_error_one_of9.py
@@ -20,7 +20,7 @@ import json
 
 
 from typing import Any, Dict
-from pydantic import BaseModel, Field, StrictStr, constr, validator
+from pydantic.v1 import BaseModel, Field, StrictStr, constr, validator
 
 class CompleteModelErrorOneOf9(BaseModel):
     """

--- a/gradientai/openapi/client/models/complete_model_error_one_of_payload.py
+++ b/gradientai/openapi/client/models/complete_model_error_one_of_payload.py
@@ -20,7 +20,7 @@ import json
 
 
 from typing import Any, Dict, List
-from pydantic import BaseModel, Field, conlist
+from pydantic.v1 import BaseModel, Field, conlist
 from gradientai.openapi.client.models.complete_model_error_one_of_payload_flagged_content_inner import CompleteModelErrorOneOfPayloadFlaggedContentInner
 
 class CompleteModelErrorOneOfPayload(BaseModel):
@@ -56,7 +56,7 @@ class CompleteModelErrorOneOfPayload(BaseModel):
                             "additional_properties"
                           },
                           exclude_none=True)
-        # override the default output from pydantic by calling `to_dict()` of each item in flagged_content (list)
+        # override the default output from pydantic.v1 by calling `to_dict()` of each item in flagged_content (list)
         _items = []
         if self.flagged_content:
             for _item in self.flagged_content:

--- a/gradientai/openapi/client/models/complete_model_error_one_of_payload_flagged_content_inner.py
+++ b/gradientai/openapi/client/models/complete_model_error_one_of_payload_flagged_content_inner.py
@@ -20,7 +20,7 @@ import json
 
 
 from typing import Any, Dict
-from pydantic import BaseModel, Field, StrictStr
+from pydantic.v1 import BaseModel, Field, StrictStr
 
 class CompleteModelErrorOneOfPayloadFlaggedContentInner(BaseModel):
     """

--- a/gradientai/openapi/client/models/complete_model_success.py
+++ b/gradientai/openapi/client/models/complete_model_success.py
@@ -20,7 +20,7 @@ import json
 
 
 from typing import Any, Dict
-from pydantic import BaseModel, Field, StrictStr
+from pydantic.v1 import BaseModel, Field, StrictStr
 
 class CompleteModelSuccess(BaseModel):
     """

--- a/gradientai/openapi/client/models/create_audio_transcription_body_params.py
+++ b/gradientai/openapi/client/models/create_audio_transcription_body_params.py
@@ -20,7 +20,7 @@ import json
 
 
 from typing import Any, Dict
-from pydantic import BaseModel, Field, constr
+from pydantic.v1 import BaseModel, Field, constr
 
 class CreateAudioTranscriptionBodyParams(BaseModel):
     """

--- a/gradientai/openapi/client/models/create_audio_transcription_error.py
+++ b/gradientai/openapi/client/models/create_audio_transcription_error.py
@@ -20,7 +20,7 @@ import json
 
 
 from typing import Any, Dict
-from pydantic import BaseModel, Field, constr
+from pydantic.v1 import BaseModel, Field, constr
 
 class CreateAudioTranscriptionError(BaseModel):
     """

--- a/gradientai/openapi/client/models/create_audio_transcription_success.py
+++ b/gradientai/openapi/client/models/create_audio_transcription_success.py
@@ -20,7 +20,7 @@ import json
 
 
 from typing import Any, Dict
-from pydantic import BaseModel, Field, constr
+from pydantic.v1 import BaseModel, Field, constr
 
 class CreateAudioTranscriptionSuccess(BaseModel):
     """

--- a/gradientai/openapi/client/models/create_model_body_params.py
+++ b/gradientai/openapi/client/models/create_model_body_params.py
@@ -20,7 +20,7 @@ import json
 
 
 from typing import Any, Dict, Optional
-from pydantic import BaseModel, Field
+from pydantic.v1 import BaseModel, Field
 from gradientai.openapi.client.models.create_model_body_params_initial_hyperparameters import CreateModelBodyParamsInitialHyperparameters
 from gradientai.openapi.client.models.create_model_body_params_model import CreateModelBodyParamsModel
 
@@ -58,10 +58,10 @@ class CreateModelBodyParams(BaseModel):
                             "additional_properties"
                           },
                           exclude_none=True)
-        # override the default output from pydantic by calling `to_dict()` of initial_hyperparameters
+        # override the default output from pydantic.v1 by calling `to_dict()` of initial_hyperparameters
         if self.initial_hyperparameters:
             _dict['initialHyperparameters'] = self.initial_hyperparameters.to_dict()
-        # override the default output from pydantic by calling `to_dict()` of model
+        # override the default output from pydantic.v1 by calling `to_dict()` of model
         if self.model:
             _dict['model'] = self.model.to_dict()
         # puts key-value pairs in additional_properties in the top level

--- a/gradientai/openapi/client/models/create_model_body_params_initial_hyperparameters.py
+++ b/gradientai/openapi/client/models/create_model_body_params_initial_hyperparameters.py
@@ -20,7 +20,7 @@ import json
 
 
 from typing import Any, Dict, Optional
-from pydantic import BaseModel, Field
+from pydantic.v1 import BaseModel, Field
 from gradientai.openapi.client.models.create_model_body_params_initial_hyperparameters_lora_hyperparameters import CreateModelBodyParamsInitialHyperparametersLoraHyperparameters
 from gradientai.openapi.client.models.create_model_body_params_initial_hyperparameters_training_arguments import CreateModelBodyParamsInitialHyperparametersTrainingArguments
 
@@ -58,10 +58,10 @@ class CreateModelBodyParamsInitialHyperparameters(BaseModel):
                             "additional_properties"
                           },
                           exclude_none=True)
-        # override the default output from pydantic by calling `to_dict()` of lora_hyperparameters
+        # override the default output from pydantic.v1 by calling `to_dict()` of lora_hyperparameters
         if self.lora_hyperparameters:
             _dict['loraHyperparameters'] = self.lora_hyperparameters.to_dict()
-        # override the default output from pydantic by calling `to_dict()` of training_arguments
+        # override the default output from pydantic.v1 by calling `to_dict()` of training_arguments
         if self.training_arguments:
             _dict['trainingArguments'] = self.training_arguments.to_dict()
         # puts key-value pairs in additional_properties in the top level

--- a/gradientai/openapi/client/models/create_model_body_params_initial_hyperparameters_lora_hyperparameters.py
+++ b/gradientai/openapi/client/models/create_model_body_params_initial_hyperparameters_lora_hyperparameters.py
@@ -20,7 +20,7 @@ import json
 
 
 from typing import Any, Dict, Optional
-from pydantic import BaseModel, conint
+from pydantic.v1 import BaseModel, conint
 
 class CreateModelBodyParamsInitialHyperparametersLoraHyperparameters(BaseModel):
     """

--- a/gradientai/openapi/client/models/create_model_body_params_initial_hyperparameters_training_arguments.py
+++ b/gradientai/openapi/client/models/create_model_body_params_initial_hyperparameters_training_arguments.py
@@ -20,7 +20,7 @@ import json
 
 
 from typing import Any, Dict, Optional, Union
-from pydantic import BaseModel, Field, confloat, conint
+from pydantic.v1 import BaseModel, Field, confloat, conint
 
 class CreateModelBodyParamsInitialHyperparametersTrainingArguments(BaseModel):
     """

--- a/gradientai/openapi/client/models/create_model_body_params_model.py
+++ b/gradientai/openapi/client/models/create_model_body_params_model.py
@@ -20,7 +20,7 @@ import json
 
 
 from typing import Any, Dict
-from pydantic import BaseModel, Field, constr
+from pydantic.v1 import BaseModel, Field, constr
 
 class CreateModelBodyParamsModel(BaseModel):
     """

--- a/gradientai/openapi/client/models/create_model_error.py
+++ b/gradientai/openapi/client/models/create_model_error.py
@@ -20,7 +20,7 @@ import json
 
 
 from typing import Any, Dict
-from pydantic import BaseModel, Field, constr
+from pydantic.v1 import BaseModel, Field, constr
 
 class CreateModelError(BaseModel):
     """

--- a/gradientai/openapi/client/models/create_model_success.py
+++ b/gradientai/openapi/client/models/create_model_success.py
@@ -20,7 +20,7 @@ import json
 
 
 from typing import Any, Dict
-from pydantic import BaseModel, Field, constr
+from pydantic.v1 import BaseModel, Field, constr
 
 class CreateModelSuccess(BaseModel):
     """

--- a/gradientai/openapi/client/models/create_rag_collection_body_params.py
+++ b/gradientai/openapi/client/models/create_rag_collection_body_params.py
@@ -20,7 +20,7 @@ import json
 
 
 from typing import Any, Dict, List, Optional
-from pydantic import BaseModel, Field, StrictStr, conlist, constr, validator
+from pydantic.v1 import BaseModel, Field, StrictStr, conlist, constr, validator
 from gradientai.openapi.client.models.create_rag_collection_body_params_files_inner import CreateRagCollectionBodyParamsFilesInner
 
 class CreateRagCollectionBodyParams(BaseModel):
@@ -65,7 +65,7 @@ class CreateRagCollectionBodyParams(BaseModel):
                             "additional_properties"
                           },
                           exclude_none=True)
-        # override the default output from pydantic by calling `to_dict()` of each item in files (list)
+        # override the default output from pydantic.v1 by calling `to_dict()` of each item in files (list)
         _items = []
         if self.files:
             for _item in self.files:

--- a/gradientai/openapi/client/models/create_rag_collection_body_params_files_inner.py
+++ b/gradientai/openapi/client/models/create_rag_collection_body_params_files_inner.py
@@ -20,7 +20,7 @@ import json
 
 
 from typing import Any, Dict
-from pydantic import BaseModel, Field, constr
+from pydantic.v1 import BaseModel, Field, constr
 
 class CreateRagCollectionBodyParamsFilesInner(BaseModel):
     """

--- a/gradientai/openapi/client/models/create_rag_collection_error.py
+++ b/gradientai/openapi/client/models/create_rag_collection_error.py
@@ -20,7 +20,7 @@ import json
 
 
 from typing import Any, Dict
-from pydantic import BaseModel, Field, constr
+from pydantic.v1 import BaseModel, Field, constr
 
 class CreateRagCollectionError(BaseModel):
     """

--- a/gradientai/openapi/client/models/create_rag_collection_success.py
+++ b/gradientai/openapi/client/models/create_rag_collection_success.py
@@ -20,7 +20,7 @@ import json
 
 
 from typing import Any, Dict
-from pydantic import BaseModel, Field, constr
+from pydantic.v1 import BaseModel, Field, constr
 
 class CreateRagCollectionSuccess(BaseModel):
     """

--- a/gradientai/openapi/client/models/delete_model_error.py
+++ b/gradientai/openapi/client/models/delete_model_error.py
@@ -20,7 +20,7 @@ import json
 
 
 from typing import Any, Dict
-from pydantic import BaseModel, Field, constr
+from pydantic.v1 import BaseModel, Field, constr
 
 class DeleteModelError(BaseModel):
     """

--- a/gradientai/openapi/client/models/delete_rag_collection_error.py
+++ b/gradientai/openapi/client/models/delete_rag_collection_error.py
@@ -20,7 +20,7 @@ import json
 
 
 from typing import Any, Dict
-from pydantic import BaseModel, Field, constr
+from pydantic.v1 import BaseModel, Field, constr
 
 class DeleteRagCollectionError(BaseModel):
     """

--- a/gradientai/openapi/client/models/extract_entity_body_params.py
+++ b/gradientai/openapi/client/models/extract_entity_body_params.py
@@ -20,7 +20,7 @@ import json
 
 
 from typing import Any, Dict
-from pydantic import BaseModel, Field, constr
+from pydantic.v1 import BaseModel, Field, constr
 from gradientai.openapi.client.models.extract_entity_body_params_schema_value import ExtractEntityBodyParamsSchemaValue
 
 class ExtractEntityBodyParams(BaseModel):
@@ -57,7 +57,7 @@ class ExtractEntityBodyParams(BaseModel):
                             "additional_properties"
                           },
                           exclude_none=True)
-        # override the default output from pydantic by calling `to_dict()` of each value in var_schema (dict)
+        # override the default output from pydantic.v1 by calling `to_dict()` of each value in var_schema (dict)
         _field_dict = {}
         if self.var_schema:
             for _key in self.var_schema:

--- a/gradientai/openapi/client/models/extract_entity_body_params_schema_value.py
+++ b/gradientai/openapi/client/models/extract_entity_body_params_schema_value.py
@@ -20,7 +20,7 @@ import json
 
 
 from typing import Any, Dict, Optional
-from pydantic import BaseModel, Field, StrictBool, StrictStr, validator
+from pydantic.v1 import BaseModel, Field, StrictBool, StrictStr, validator
 
 class ExtractEntityBodyParamsSchemaValue(BaseModel):
     """

--- a/gradientai/openapi/client/models/extract_entity_error.py
+++ b/gradientai/openapi/client/models/extract_entity_error.py
@@ -20,7 +20,7 @@ import json
 
 
 from typing import Any, Dict
-from pydantic import BaseModel, Field, constr
+from pydantic.v1 import BaseModel, Field, constr
 
 class ExtractEntityError(BaseModel):
     """

--- a/gradientai/openapi/client/models/extract_entity_success.py
+++ b/gradientai/openapi/client/models/extract_entity_success.py
@@ -20,7 +20,7 @@ import json
 
 
 from typing import Any, Dict
-from pydantic import BaseModel, Field
+from pydantic.v1 import BaseModel, Field
 from gradientai.openapi.client.models.extract_entity_success_entity_value import ExtractEntitySuccessEntityValue
 
 class ExtractEntitySuccess(BaseModel):
@@ -56,7 +56,7 @@ class ExtractEntitySuccess(BaseModel):
                             "additional_properties"
                           },
                           exclude_none=True)
-        # override the default output from pydantic by calling `to_dict()` of each value in entity (dict)
+        # override the default output from pydantic.v1 by calling `to_dict()` of each value in entity (dict)
         _field_dict = {}
         if self.entity:
             for _key in self.entity:

--- a/gradientai/openapi/client/models/extract_entity_success_entity_value.py
+++ b/gradientai/openapi/client/models/extract_entity_success_entity_value.py
@@ -20,9 +20,9 @@ import pprint
 import re  # noqa: F401
 
 from typing import Optional, Union
-from pydantic import BaseModel, Field, StrictBool, StrictFloat, StrictInt, StrictStr, ValidationError, validator
+from pydantic.v1 import BaseModel, Field, StrictBool, StrictFloat, StrictInt, StrictStr, ValidationError, validator
 from typing import Any, List
-from pydantic import StrictStr, Field
+from pydantic.v1 import StrictStr, Field
 
 EXTRACTENTITYSUCCESSENTITYVALUE_ANY_OF_SCHEMAS = ["bool", "float", "str"]
 

--- a/gradientai/openapi/client/models/extract_pdf_error.py
+++ b/gradientai/openapi/client/models/extract_pdf_error.py
@@ -20,7 +20,7 @@ import json
 
 
 from typing import Any, Dict
-from pydantic import BaseModel, Field, constr
+from pydantic.v1 import BaseModel, Field, constr
 
 class ExtractPdfError(BaseModel):
     """

--- a/gradientai/openapi/client/models/extract_pdf_success.py
+++ b/gradientai/openapi/client/models/extract_pdf_success.py
@@ -20,7 +20,7 @@ import json
 
 
 from typing import Any, Dict, List, Optional
-from pydantic import BaseModel, Field, StrictStr, conlist
+from pydantic.v1 import BaseModel, Field, StrictStr, conlist
 from gradientai.openapi.client.models.extract_pdf_success_pages_inner import ExtractPdfSuccessPagesInner
 
 class ExtractPdfSuccess(BaseModel):
@@ -58,7 +58,7 @@ class ExtractPdfSuccess(BaseModel):
                             "additional_properties"
                           },
                           exclude_none=True)
-        # override the default output from pydantic by calling `to_dict()` of each item in pages (list)
+        # override the default output from pydantic.v1 by calling `to_dict()` of each item in pages (list)
         _items = []
         if self.pages:
             for _item in self.pages:

--- a/gradientai/openapi/client/models/extract_pdf_success_pages_inner.py
+++ b/gradientai/openapi/client/models/extract_pdf_success_pages_inner.py
@@ -20,7 +20,7 @@ import json
 
 
 from typing import Any, Dict, List
-from pydantic import BaseModel, Field, StrictStr, conint, conlist
+from pydantic.v1 import BaseModel, Field, StrictStr, conint, conlist
 from gradientai.openapi.client.models.extract_pdf_success_pages_inner_images_inner import ExtractPdfSuccessPagesInnerImagesInner
 from gradientai.openapi.client.models.extract_pdf_success_pages_inner_tables_inner import ExtractPdfSuccessPagesInnerTablesInner
 from gradientai.openapi.client.models.extract_pdf_success_pages_inner_text_blocks_inner import ExtractPdfSuccessPagesInnerTextBlocksInner
@@ -62,21 +62,21 @@ class ExtractPdfSuccessPagesInner(BaseModel):
                             "additional_properties"
                           },
                           exclude_none=True)
-        # override the default output from pydantic by calling `to_dict()` of each item in images (list)
+        # override the default output from pydantic.v1 by calling `to_dict()` of each item in images (list)
         _items = []
         if self.images:
             for _item in self.images:
                 if _item:
                     _items.append(_item.to_dict())
             _dict['images'] = _items
-        # override the default output from pydantic by calling `to_dict()` of each item in tables (list)
+        # override the default output from pydantic.v1 by calling `to_dict()` of each item in tables (list)
         _items = []
         if self.tables:
             for _item in self.tables:
                 if _item:
                     _items.append(_item.to_dict())
             _dict['tables'] = _items
-        # override the default output from pydantic by calling `to_dict()` of each item in text_blocks (list)
+        # override the default output from pydantic.v1 by calling `to_dict()` of each item in text_blocks (list)
         _items = []
         if self.text_blocks:
             for _item in self.text_blocks:

--- a/gradientai/openapi/client/models/extract_pdf_success_pages_inner_images_inner.py
+++ b/gradientai/openapi/client/models/extract_pdf_success_pages_inner_images_inner.py
@@ -20,7 +20,7 @@ import json
 
 
 from typing import Any, Dict
-from pydantic import BaseModel, Field, StrictStr, validator
+from pydantic.v1 import BaseModel, Field, StrictStr, validator
 
 class ExtractPdfSuccessPagesInnerImagesInner(BaseModel):
     """

--- a/gradientai/openapi/client/models/extract_pdf_success_pages_inner_tables_inner.py
+++ b/gradientai/openapi/client/models/extract_pdf_success_pages_inner_tables_inner.py
@@ -20,7 +20,7 @@ import json
 
 
 from typing import Any, Dict, List
-from pydantic import BaseModel, Field, StrictStr, conlist
+from pydantic.v1 import BaseModel, Field, StrictStr, conlist
 from gradientai.openapi.client.models.extract_pdf_success_pages_inner_tables_inner_table_rows_inner import ExtractPdfSuccessPagesInnerTablesInnerTableRowsInner
 
 class ExtractPdfSuccessPagesInnerTablesInner(BaseModel):
@@ -57,7 +57,7 @@ class ExtractPdfSuccessPagesInnerTablesInner(BaseModel):
                             "additional_properties"
                           },
                           exclude_none=True)
-        # override the default output from pydantic by calling `to_dict()` of each item in table_rows (list)
+        # override the default output from pydantic.v1 by calling `to_dict()` of each item in table_rows (list)
         _items = []
         if self.table_rows:
             for _item in self.table_rows:

--- a/gradientai/openapi/client/models/extract_pdf_success_pages_inner_tables_inner_table_rows_inner.py
+++ b/gradientai/openapi/client/models/extract_pdf_success_pages_inner_tables_inner_table_rows_inner.py
@@ -20,7 +20,7 @@ import json
 
 
 from typing import Any, Dict, List
-from pydantic import BaseModel, Field, StrictStr, conlist, validator
+from pydantic.v1 import BaseModel, Field, StrictStr, conlist, validator
 from gradientai.openapi.client.models.extract_pdf_success_pages_inner_tables_inner_table_rows_inner_cells_inner import ExtractPdfSuccessPagesInnerTablesInnerTableRowsInnerCellsInner
 
 class ExtractPdfSuccessPagesInnerTablesInnerTableRowsInner(BaseModel):
@@ -64,7 +64,7 @@ class ExtractPdfSuccessPagesInnerTablesInnerTableRowsInner(BaseModel):
                             "additional_properties"
                           },
                           exclude_none=True)
-        # override the default output from pydantic by calling `to_dict()` of each item in cells (list)
+        # override the default output from pydantic.v1 by calling `to_dict()` of each item in cells (list)
         _items = []
         if self.cells:
             for _item in self.cells:

--- a/gradientai/openapi/client/models/extract_pdf_success_pages_inner_tables_inner_table_rows_inner_cells_inner.py
+++ b/gradientai/openapi/client/models/extract_pdf_success_pages_inner_tables_inner_table_rows_inner_cells_inner.py
@@ -20,7 +20,7 @@ import json
 
 
 from typing import Any, Dict, Optional
-from pydantic import BaseModel, Field, StrictStr, conint
+from pydantic.v1 import BaseModel, Field, StrictStr, conint
 
 class ExtractPdfSuccessPagesInnerTablesInnerTableRowsInnerCellsInner(BaseModel):
     """

--- a/gradientai/openapi/client/models/extract_pdf_success_pages_inner_text_blocks_inner.py
+++ b/gradientai/openapi/client/models/extract_pdf_success_pages_inner_text_blocks_inner.py
@@ -20,7 +20,7 @@ import json
 
 
 from typing import Any, Dict, List
-from pydantic import BaseModel, Field, StrictStr, conlist, validator
+from pydantic.v1 import BaseModel, Field, StrictStr, conlist, validator
 
 class ExtractPdfSuccessPagesInnerTextBlocksInner(BaseModel):
     """

--- a/gradientai/openapi/client/models/fine_tune_model_body_params.py
+++ b/gradientai/openapi/client/models/fine_tune_model_body_params.py
@@ -20,7 +20,7 @@ import json
 
 
 from typing import Any, Dict, List
-from pydantic import BaseModel, Field, conlist
+from pydantic.v1 import BaseModel, Field, conlist
 from gradientai.openapi.client.models.fine_tune_model_body_params_samples_inner import FineTuneModelBodyParamsSamplesInner
 
 class FineTuneModelBodyParams(BaseModel):
@@ -56,7 +56,7 @@ class FineTuneModelBodyParams(BaseModel):
                             "additional_properties"
                           },
                           exclude_none=True)
-        # override the default output from pydantic by calling `to_dict()` of each item in samples (list)
+        # override the default output from pydantic.v1 by calling `to_dict()` of each item in samples (list)
         _items = []
         if self.samples:
             for _item in self.samples:

--- a/gradientai/openapi/client/models/fine_tune_model_body_params_samples_inner.py
+++ b/gradientai/openapi/client/models/fine_tune_model_body_params_samples_inner.py
@@ -20,7 +20,7 @@ import json
 
 
 from typing import Any, Dict, Optional
-from pydantic import BaseModel, Field
+from pydantic.v1 import BaseModel, Field
 from gradientai.openapi.client.models.fine_tune_model_body_params_samples_inner_fine_tuning_parameters import FineTuneModelBodyParamsSamplesInnerFineTuningParameters
 from gradientai.openapi.client.models.fine_tune_model_body_params_samples_inner_inputs import FineTuneModelBodyParamsSamplesInnerInputs
 
@@ -58,10 +58,10 @@ class FineTuneModelBodyParamsSamplesInner(BaseModel):
                             "additional_properties"
                           },
                           exclude_none=True)
-        # override the default output from pydantic by calling `to_dict()` of fine_tuning_parameters
+        # override the default output from pydantic.v1 by calling `to_dict()` of fine_tuning_parameters
         if self.fine_tuning_parameters:
             _dict['fineTuningParameters'] = self.fine_tuning_parameters.to_dict()
-        # override the default output from pydantic by calling `to_dict()` of inputs
+        # override the default output from pydantic.v1 by calling `to_dict()` of inputs
         if self.inputs:
             _dict['inputs'] = self.inputs.to_dict()
         # puts key-value pairs in additional_properties in the top level

--- a/gradientai/openapi/client/models/fine_tune_model_body_params_samples_inner_fine_tuning_parameters.py
+++ b/gradientai/openapi/client/models/fine_tune_model_body_params_samples_inner_fine_tuning_parameters.py
@@ -20,7 +20,7 @@ import json
 
 
 from typing import Any, Dict, Optional, Union
-from pydantic import BaseModel, confloat, conint
+from pydantic.v1 import BaseModel, confloat, conint
 
 class FineTuneModelBodyParamsSamplesInnerFineTuningParameters(BaseModel):
     """

--- a/gradientai/openapi/client/models/fine_tune_model_body_params_samples_inner_inputs.py
+++ b/gradientai/openapi/client/models/fine_tune_model_body_params_samples_inner_inputs.py
@@ -20,10 +20,10 @@ import pprint
 import re  # noqa: F401
 
 from typing import List, Optional
-from pydantic import BaseModel, Field, StrictStr, ValidationError, conlist, constr, validator
+from pydantic.v1 import BaseModel, Field, StrictStr, ValidationError, conlist, constr, validator
 from gradientai.openapi.client.models.fine_tune_model_body_params_samples_inner_inputs_any_of_inner import FineTuneModelBodyParamsSamplesInnerInputsAnyOfInner
 from typing import Any, List
-from pydantic import StrictStr, Field
+from pydantic.v1 import StrictStr, Field
 
 FINETUNEMODELBODYPARAMSSAMPLESINNERINPUTS_ANY_OF_SCHEMAS = ["List[FineTuneModelBodyParamsSamplesInnerInputsAnyOfInner]", "str"]
 

--- a/gradientai/openapi/client/models/fine_tune_model_body_params_samples_inner_inputs_any_of_inner.py
+++ b/gradientai/openapi/client/models/fine_tune_model_body_params_samples_inner_inputs_any_of_inner.py
@@ -20,7 +20,7 @@ import json
 
 
 from typing import Any, Dict, Optional
-from pydantic import BaseModel, Field, StrictBool, constr
+from pydantic.v1 import BaseModel, Field, StrictBool, constr
 
 class FineTuneModelBodyParamsSamplesInnerInputsAnyOfInner(BaseModel):
     """

--- a/gradientai/openapi/client/models/fine_tune_model_error.py
+++ b/gradientai/openapi/client/models/fine_tune_model_error.py
@@ -20,7 +20,7 @@ import pprint
 import re  # noqa: F401
 
 from typing import Any, List, Optional
-from pydantic import BaseModel, Field, StrictStr, ValidationError, validator
+from pydantic.v1 import BaseModel, Field, StrictStr, ValidationError, validator
 from gradientai.openapi.client.models.complete_model_error_one_of import CompleteModelErrorOneOf
 from gradientai.openapi.client.models.complete_model_error_one_of1 import CompleteModelErrorOneOf1
 from gradientai.openapi.client.models.complete_model_error_one_of10 import CompleteModelErrorOneOf10
@@ -29,7 +29,7 @@ from gradientai.openapi.client.models.complete_model_error_one_of8 import Comple
 from gradientai.openapi.client.models.fine_tune_model_error_one_of import FineTuneModelErrorOneOf
 from gradientai.openapi.client.models.fine_tune_model_error_one_of1 import FineTuneModelErrorOneOf1
 from typing import Any, List
-from pydantic import StrictStr, Field
+from pydantic.v1 import StrictStr, Field
 
 FINETUNEMODELERROR_ONE_OF_SCHEMAS = ["CompleteModelErrorOneOf", "CompleteModelErrorOneOf1", "CompleteModelErrorOneOf10", "CompleteModelErrorOneOf2", "CompleteModelErrorOneOf8", "FineTuneModelErrorOneOf", "FineTuneModelErrorOneOf1"]
 

--- a/gradientai/openapi/client/models/fine_tune_model_error_one_of.py
+++ b/gradientai/openapi/client/models/fine_tune_model_error_one_of.py
@@ -20,7 +20,7 @@ import json
 
 
 from typing import Any, Dict
-from pydantic import BaseModel, Field, StrictStr, constr, validator
+from pydantic.v1 import BaseModel, Field, StrictStr, constr, validator
 
 class FineTuneModelErrorOneOf(BaseModel):
     """

--- a/gradientai/openapi/client/models/fine_tune_model_error_one_of1.py
+++ b/gradientai/openapi/client/models/fine_tune_model_error_one_of1.py
@@ -20,7 +20,7 @@ import json
 
 
 from typing import Any, Dict
-from pydantic import BaseModel, Field, StrictStr, constr, validator
+from pydantic.v1 import BaseModel, Field, StrictStr, constr, validator
 
 class FineTuneModelErrorOneOf1(BaseModel):
     """

--- a/gradientai/openapi/client/models/fine_tune_model_success.py
+++ b/gradientai/openapi/client/models/fine_tune_model_success.py
@@ -20,7 +20,7 @@ import json
 
 
 from typing import Any, Dict, Union
-from pydantic import BaseModel, Field, StrictFloat, StrictInt, conint
+from pydantic.v1 import BaseModel, Field, StrictFloat, StrictInt, conint
 
 class FineTuneModelSuccess(BaseModel):
     """

--- a/gradientai/openapi/client/models/generate_answer_body_params.py
+++ b/gradientai/openapi/client/models/generate_answer_body_params.py
@@ -20,7 +20,7 @@ import json
 
 
 from typing import Any, Dict
-from pydantic import BaseModel, Field, constr
+from pydantic.v1 import BaseModel, Field, constr
 from gradientai.openapi.client.models.generate_answer_body_params_source import GenerateAnswerBodyParamsSource
 
 class GenerateAnswerBodyParams(BaseModel):
@@ -57,7 +57,7 @@ class GenerateAnswerBodyParams(BaseModel):
                             "additional_properties"
                           },
                           exclude_none=True)
-        # override the default output from pydantic by calling `to_dict()` of source
+        # override the default output from pydantic.v1 by calling `to_dict()` of source
         if self.source:
             _dict['source'] = self.source.to_dict()
         # puts key-value pairs in additional_properties in the top level

--- a/gradientai/openapi/client/models/generate_answer_body_params_source.py
+++ b/gradientai/openapi/client/models/generate_answer_body_params_source.py
@@ -20,11 +20,11 @@ import pprint
 import re  # noqa: F401
 
 from typing import Any, List, Optional
-from pydantic import BaseModel, Field, StrictStr, ValidationError, validator
+from pydantic.v1 import BaseModel, Field, StrictStr, ValidationError, validator
 from gradientai.openapi.client.models.generate_answer_body_params_source_one_of import GenerateAnswerBodyParamsSourceOneOf
 from gradientai.openapi.client.models.generate_answer_body_params_source_one_of1 import GenerateAnswerBodyParamsSourceOneOf1
 from typing import Any, List
-from pydantic import StrictStr, Field
+from pydantic.v1 import StrictStr, Field
 
 GENERATEANSWERBODYPARAMSSOURCE_ONE_OF_SCHEMAS = ["GenerateAnswerBodyParamsSourceOneOf", "GenerateAnswerBodyParamsSourceOneOf1"]
 

--- a/gradientai/openapi/client/models/generate_answer_body_params_source_one_of.py
+++ b/gradientai/openapi/client/models/generate_answer_body_params_source_one_of.py
@@ -20,7 +20,7 @@ import json
 
 
 from typing import Any, Dict
-from pydantic import BaseModel, Field, StrictStr, constr, validator
+from pydantic.v1 import BaseModel, Field, StrictStr, constr, validator
 
 class GenerateAnswerBodyParamsSourceOneOf(BaseModel):
     """

--- a/gradientai/openapi/client/models/generate_answer_body_params_source_one_of1.py
+++ b/gradientai/openapi/client/models/generate_answer_body_params_source_one_of1.py
@@ -20,7 +20,7 @@ import json
 
 
 from typing import Any, Dict
-from pydantic import BaseModel, Field, StrictStr, constr, validator
+from pydantic.v1 import BaseModel, Field, StrictStr, constr, validator
 
 class GenerateAnswerBodyParamsSourceOneOf1(BaseModel):
     """

--- a/gradientai/openapi/client/models/generate_answer_error.py
+++ b/gradientai/openapi/client/models/generate_answer_error.py
@@ -20,7 +20,7 @@ import json
 
 
 from typing import Any, Dict
-from pydantic import BaseModel, Field, constr
+from pydantic.v1 import BaseModel, Field, constr
 
 class GenerateAnswerError(BaseModel):
     """

--- a/gradientai/openapi/client/models/generate_answer_success.py
+++ b/gradientai/openapi/client/models/generate_answer_success.py
@@ -20,7 +20,7 @@ import json
 
 
 from typing import Any, Dict, Optional
-from pydantic import BaseModel, Field, constr
+from pydantic.v1 import BaseModel, Field, constr
 from gradientai.openapi.client.models.generate_answer_success_rag_context import GenerateAnswerSuccessRagContext
 
 class GenerateAnswerSuccess(BaseModel):
@@ -57,7 +57,7 @@ class GenerateAnswerSuccess(BaseModel):
                             "additional_properties"
                           },
                           exclude_none=True)
-        # override the default output from pydantic by calling `to_dict()` of rag_context
+        # override the default output from pydantic.v1 by calling `to_dict()` of rag_context
         if self.rag_context:
             _dict['ragContext'] = self.rag_context.to_dict()
         # puts key-value pairs in additional_properties in the top level

--- a/gradientai/openapi/client/models/generate_answer_success_rag_context.py
+++ b/gradientai/openapi/client/models/generate_answer_success_rag_context.py
@@ -20,7 +20,7 @@ import json
 
 
 from typing import Any, Dict, List
-from pydantic import BaseModel, Field, conlist
+from pydantic.v1 import BaseModel, Field, conlist
 from gradientai.openapi.client.models.generate_answer_success_rag_context_documents_inner import GenerateAnswerSuccessRagContextDocumentsInner
 
 class GenerateAnswerSuccessRagContext(BaseModel):
@@ -56,7 +56,7 @@ class GenerateAnswerSuccessRagContext(BaseModel):
                             "additional_properties"
                           },
                           exclude_none=True)
-        # override the default output from pydantic by calling `to_dict()` of each item in documents (list)
+        # override the default output from pydantic.v1 by calling `to_dict()` of each item in documents (list)
         _items = []
         if self.documents:
             for _item in self.documents:

--- a/gradientai/openapi/client/models/generate_answer_success_rag_context_documents_inner.py
+++ b/gradientai/openapi/client/models/generate_answer_success_rag_context_documents_inner.py
@@ -20,7 +20,7 @@ import json
 
 
 from typing import Any, Dict
-from pydantic import BaseModel, Field, constr
+from pydantic.v1 import BaseModel, Field, constr
 
 class GenerateAnswerSuccessRagContextDocumentsInner(BaseModel):
     """

--- a/gradientai/openapi/client/models/generate_embedding_body_params.py
+++ b/gradientai/openapi/client/models/generate_embedding_body_params.py
@@ -20,7 +20,7 @@ import json
 
 
 from typing import Any, Dict, List
-from pydantic import BaseModel, Field, conlist
+from pydantic.v1 import BaseModel, Field, conlist
 from gradientai.openapi.client.models.generate_embedding_body_params_inputs_inner import GenerateEmbeddingBodyParamsInputsInner
 
 class GenerateEmbeddingBodyParams(BaseModel):
@@ -56,7 +56,7 @@ class GenerateEmbeddingBodyParams(BaseModel):
                             "additional_properties"
                           },
                           exclude_none=True)
-        # override the default output from pydantic by calling `to_dict()` of each item in inputs (list)
+        # override the default output from pydantic.v1 by calling `to_dict()` of each item in inputs (list)
         _items = []
         if self.inputs:
             for _item in self.inputs:

--- a/gradientai/openapi/client/models/generate_embedding_body_params_inputs_inner.py
+++ b/gradientai/openapi/client/models/generate_embedding_body_params_inputs_inner.py
@@ -20,7 +20,7 @@ import json
 
 
 from typing import Any, Dict
-from pydantic import BaseModel, Field, constr
+from pydantic.v1 import BaseModel, Field, constr
 
 class GenerateEmbeddingBodyParamsInputsInner(BaseModel):
     """

--- a/gradientai/openapi/client/models/generate_embedding_error.py
+++ b/gradientai/openapi/client/models/generate_embedding_error.py
@@ -20,7 +20,7 @@ import json
 
 
 from typing import Any, Dict
-from pydantic import BaseModel, Field, constr
+from pydantic.v1 import BaseModel, Field, constr
 
 class GenerateEmbeddingError(BaseModel):
     """

--- a/gradientai/openapi/client/models/generate_embedding_success.py
+++ b/gradientai/openapi/client/models/generate_embedding_success.py
@@ -20,7 +20,7 @@ import json
 
 
 from typing import Any, Dict, List
-from pydantic import BaseModel, Field, conlist
+from pydantic.v1 import BaseModel, Field, conlist
 from gradientai.openapi.client.models.generate_embedding_success_embeddings_inner import GenerateEmbeddingSuccessEmbeddingsInner
 
 class GenerateEmbeddingSuccess(BaseModel):
@@ -56,7 +56,7 @@ class GenerateEmbeddingSuccess(BaseModel):
                             "additional_properties"
                           },
                           exclude_none=True)
-        # override the default output from pydantic by calling `to_dict()` of each item in embeddings (list)
+        # override the default output from pydantic.v1 by calling `to_dict()` of each item in embeddings (list)
         _items = []
         if self.embeddings:
             for _item in self.embeddings:

--- a/gradientai/openapi/client/models/generate_embedding_success_embeddings_inner.py
+++ b/gradientai/openapi/client/models/generate_embedding_success_embeddings_inner.py
@@ -20,7 +20,7 @@ import json
 
 
 from typing import Any, Dict, List, Union
-from pydantic import BaseModel, Field, StrictFloat, StrictInt, conint, conlist
+from pydantic.v1 import BaseModel, Field, StrictFloat, StrictInt, conint, conlist
 
 class GenerateEmbeddingSuccessEmbeddingsInner(BaseModel):
     """

--- a/gradientai/openapi/client/models/get_audio_transcription_error.py
+++ b/gradientai/openapi/client/models/get_audio_transcription_error.py
@@ -20,7 +20,7 @@ import json
 
 
 from typing import Any, Dict
-from pydantic import BaseModel, Field, constr
+from pydantic.v1 import BaseModel, Field, constr
 
 class GetAudioTranscriptionError(BaseModel):
     """

--- a/gradientai/openapi/client/models/get_audio_transcription_success.py
+++ b/gradientai/openapi/client/models/get_audio_transcription_success.py
@@ -20,11 +20,11 @@ import pprint
 import re  # noqa: F401
 
 from typing import Any, List, Optional
-from pydantic import BaseModel, Field, StrictStr, ValidationError, validator
+from pydantic.v1 import BaseModel, Field, StrictStr, ValidationError, validator
 from gradientai.openapi.client.models.get_audio_transcription_success_one_of import GetAudioTranscriptionSuccessOneOf
 from gradientai.openapi.client.models.get_audio_transcription_success_one_of1 import GetAudioTranscriptionSuccessOneOf1
 from typing import Any, List
-from pydantic import StrictStr, Field
+from pydantic.v1 import StrictStr, Field
 
 GETAUDIOTRANSCRIPTIONSUCCESS_ONE_OF_SCHEMAS = ["GetAudioTranscriptionSuccessOneOf", "GetAudioTranscriptionSuccessOneOf1"]
 

--- a/gradientai/openapi/client/models/get_audio_transcription_success_one_of.py
+++ b/gradientai/openapi/client/models/get_audio_transcription_success_one_of.py
@@ -20,7 +20,7 @@ import json
 
 
 from typing import Any, Dict, Optional
-from pydantic import BaseModel, Field, StrictStr, validator
+from pydantic.v1 import BaseModel, Field, StrictStr, validator
 
 class GetAudioTranscriptionSuccessOneOf(BaseModel):
     """

--- a/gradientai/openapi/client/models/get_audio_transcription_success_one_of1.py
+++ b/gradientai/openapi/client/models/get_audio_transcription_success_one_of1.py
@@ -20,7 +20,7 @@ import json
 
 
 from typing import Any, Dict
-from pydantic import BaseModel, Field, StrictStr, validator
+from pydantic.v1 import BaseModel, Field, StrictStr, validator
 from gradientai.openapi.client.models.get_audio_transcription_success_one_of1_result import GetAudioTranscriptionSuccessOneOf1Result
 
 class GetAudioTranscriptionSuccessOneOf1(BaseModel):
@@ -64,7 +64,7 @@ class GetAudioTranscriptionSuccessOneOf1(BaseModel):
                             "additional_properties"
                           },
                           exclude_none=True)
-        # override the default output from pydantic by calling `to_dict()` of result
+        # override the default output from pydantic.v1 by calling `to_dict()` of result
         if self.result:
             _dict['result'] = self.result.to_dict()
         # puts key-value pairs in additional_properties in the top level

--- a/gradientai/openapi/client/models/get_audio_transcription_success_one_of1_result.py
+++ b/gradientai/openapi/client/models/get_audio_transcription_success_one_of1_result.py
@@ -20,7 +20,7 @@ import json
 
 
 from typing import Any, Dict
-from pydantic import BaseModel, Field, StrictStr
+from pydantic.v1 import BaseModel, Field, StrictStr
 
 class GetAudioTranscriptionSuccessOneOf1Result(BaseModel):
     """

--- a/gradientai/openapi/client/models/get_model_error.py
+++ b/gradientai/openapi/client/models/get_model_error.py
@@ -20,7 +20,7 @@ import json
 
 
 from typing import Any, Dict
-from pydantic import BaseModel, Field, constr
+from pydantic.v1 import BaseModel, Field, constr
 
 class GetModelError(BaseModel):
     """

--- a/gradientai/openapi/client/models/get_model_success.py
+++ b/gradientai/openapi/client/models/get_model_success.py
@@ -20,7 +20,7 @@ import json
 
 from datetime import datetime
 from typing import Any, Dict
-from pydantic import BaseModel, Field, StrictStr, constr, validator
+from pydantic.v1 import BaseModel, Field, StrictStr, constr, validator
 
 class GetModelSuccess(BaseModel):
     """

--- a/gradientai/openapi/client/models/get_rag_collection_error.py
+++ b/gradientai/openapi/client/models/get_rag_collection_error.py
@@ -20,7 +20,7 @@ import json
 
 
 from typing import Any, Dict
-from pydantic import BaseModel, Field, constr
+from pydantic.v1 import BaseModel, Field, constr
 
 class GetRagCollectionError(BaseModel):
     """

--- a/gradientai/openapi/client/models/get_rag_collection_success.py
+++ b/gradientai/openapi/client/models/get_rag_collection_success.py
@@ -20,7 +20,7 @@ import json
 
 from datetime import datetime
 from typing import Any, Dict, List
-from pydantic import BaseModel, Field, StrictStr, conlist, constr, validator
+from pydantic.v1 import BaseModel, Field, StrictStr, conlist, constr, validator
 from gradientai.openapi.client.models.get_rag_collection_success_files_inner import GetRagCollectionSuccessFilesInner
 
 class GetRagCollectionSuccess(BaseModel):
@@ -67,7 +67,7 @@ class GetRagCollectionSuccess(BaseModel):
                             "additional_properties"
                           },
                           exclude_none=True)
-        # override the default output from pydantic by calling `to_dict()` of each item in files (list)
+        # override the default output from pydantic.v1 by calling `to_dict()` of each item in files (list)
         _items = []
         if self.files:
             for _item in self.files:

--- a/gradientai/openapi/client/models/get_rag_collection_success_files_inner.py
+++ b/gradientai/openapi/client/models/get_rag_collection_success_files_inner.py
@@ -20,7 +20,7 @@ import json
 
 
 from typing import Any, Dict
-from pydantic import BaseModel, Field, StrictStr, constr, validator
+from pydantic.v1 import BaseModel, Field, StrictStr, constr, validator
 
 class GetRagCollectionSuccessFilesInner(BaseModel):
     """

--- a/gradientai/openapi/client/models/list_embeddings_error.py
+++ b/gradientai/openapi/client/models/list_embeddings_error.py
@@ -20,7 +20,7 @@ import json
 
 
 from typing import Any, Dict
-from pydantic import BaseModel, Field, constr
+from pydantic.v1 import BaseModel, Field, constr
 
 class ListEmbeddingsError(BaseModel):
     """

--- a/gradientai/openapi/client/models/list_embeddings_success.py
+++ b/gradientai/openapi/client/models/list_embeddings_success.py
@@ -20,7 +20,7 @@ import json
 
 
 from typing import Any, Dict, List
-from pydantic import BaseModel, Field, conlist
+from pydantic.v1 import BaseModel, Field, conlist
 from gradientai.openapi.client.models.list_embeddings_success_embeddings_models_inner import ListEmbeddingsSuccessEmbeddingsModelsInner
 
 class ListEmbeddingsSuccess(BaseModel):
@@ -56,7 +56,7 @@ class ListEmbeddingsSuccess(BaseModel):
                             "additional_properties"
                           },
                           exclude_none=True)
-        # override the default output from pydantic by calling `to_dict()` of each item in embeddings_models (list)
+        # override the default output from pydantic.v1 by calling `to_dict()` of each item in embeddings_models (list)
         _items = []
         if self.embeddings_models:
             for _item in self.embeddings_models:

--- a/gradientai/openapi/client/models/list_embeddings_success_embeddings_models_inner.py
+++ b/gradientai/openapi/client/models/list_embeddings_success_embeddings_models_inner.py
@@ -20,7 +20,7 @@ import json
 
 
 from typing import Any, Dict
-from pydantic import BaseModel, Field, StrictStr, validator
+from pydantic.v1 import BaseModel, Field, StrictStr, validator
 
 class ListEmbeddingsSuccessEmbeddingsModelsInner(BaseModel):
     """

--- a/gradientai/openapi/client/models/list_models_error.py
+++ b/gradientai/openapi/client/models/list_models_error.py
@@ -20,7 +20,7 @@ import json
 
 
 from typing import Any, Dict
-from pydantic import BaseModel, Field, constr
+from pydantic.v1 import BaseModel, Field, constr
 
 class ListModelsError(BaseModel):
     """

--- a/gradientai/openapi/client/models/list_models_success.py
+++ b/gradientai/openapi/client/models/list_models_success.py
@@ -20,7 +20,7 @@ import json
 
 
 from typing import Any, Dict, List
-from pydantic import BaseModel, Field, conlist
+from pydantic.v1 import BaseModel, Field, conlist
 from gradientai.openapi.client.models.list_models_success_models_inner import ListModelsSuccessModelsInner
 
 class ListModelsSuccess(BaseModel):
@@ -56,7 +56,7 @@ class ListModelsSuccess(BaseModel):
                             "additional_properties"
                           },
                           exclude_none=True)
-        # override the default output from pydantic by calling `to_dict()` of each item in models (list)
+        # override the default output from pydantic.v1 by calling `to_dict()` of each item in models (list)
         _items = []
         if self.models:
             for _item in self.models:

--- a/gradientai/openapi/client/models/list_models_success_models_inner.py
+++ b/gradientai/openapi/client/models/list_models_success_models_inner.py
@@ -20,11 +20,11 @@ import pprint
 import re  # noqa: F401
 
 from typing import Any, List, Optional
-from pydantic import BaseModel, Field, StrictStr, ValidationError, validator
+from pydantic.v1 import BaseModel, Field, StrictStr, ValidationError, validator
 from gradientai.openapi.client.models.base_model import BaseModel
 from gradientai.openapi.client.models.model_adapter import ModelAdapter
 from typing import Any, List
-from pydantic import StrictStr, Field
+from pydantic.v1 import StrictStr, Field
 
 LISTMODELSSUCCESSMODELSINNER_ONE_OF_SCHEMAS = ["BaseModel", "ModelAdapter"]
 

--- a/gradientai/openapi/client/models/list_rag_collections_error.py
+++ b/gradientai/openapi/client/models/list_rag_collections_error.py
@@ -20,7 +20,7 @@ import json
 
 
 from typing import Any, Dict
-from pydantic import BaseModel, Field, constr
+from pydantic.v1 import BaseModel, Field, constr
 
 class ListRagCollectionsError(BaseModel):
     """

--- a/gradientai/openapi/client/models/list_rag_collections_success.py
+++ b/gradientai/openapi/client/models/list_rag_collections_success.py
@@ -20,7 +20,7 @@ import json
 
 
 from typing import Any, Dict, List
-from pydantic import BaseModel, Field, conlist
+from pydantic.v1 import BaseModel, Field, conlist
 from gradientai.openapi.client.models.list_rag_collections_success_rag_collections_inner import ListRagCollectionsSuccessRagCollectionsInner
 
 class ListRagCollectionsSuccess(BaseModel):
@@ -56,7 +56,7 @@ class ListRagCollectionsSuccess(BaseModel):
                             "additional_properties"
                           },
                           exclude_none=True)
-        # override the default output from pydantic by calling `to_dict()` of each item in rag_collections (list)
+        # override the default output from pydantic.v1 by calling `to_dict()` of each item in rag_collections (list)
         _items = []
         if self.rag_collections:
             for _item in self.rag_collections:

--- a/gradientai/openapi/client/models/list_rag_collections_success_rag_collections_inner.py
+++ b/gradientai/openapi/client/models/list_rag_collections_success_rag_collections_inner.py
@@ -20,7 +20,7 @@ import json
 
 from datetime import datetime
 from typing import Any, Dict
-from pydantic import BaseModel, Field, StrictStr, constr, validator
+from pydantic.v1 import BaseModel, Field, StrictStr, constr, validator
 
 class ListRagCollectionsSuccessRagCollectionsInner(BaseModel):
     """

--- a/gradientai/openapi/client/models/model_adapter.py
+++ b/gradientai/openapi/client/models/model_adapter.py
@@ -20,7 +20,7 @@ import json
 
 from datetime import datetime
 from typing import Any, Dict
-from pydantic import BaseModel, Field, StrictStr, constr, validator
+from pydantic.v1 import BaseModel, Field, StrictStr, constr, validator
 
 class ModelAdapter(BaseModel):
     """

--- a/gradientai/openapi/client/models/personalize_document_body_params.py
+++ b/gradientai/openapi/client/models/personalize_document_body_params.py
@@ -20,7 +20,7 @@ import json
 
 
 from typing import Any, Dict
-from pydantic import BaseModel, Field, constr
+from pydantic.v1 import BaseModel, Field, constr
 
 class PersonalizeDocumentBodyParams(BaseModel):
     """

--- a/gradientai/openapi/client/models/personalize_document_error.py
+++ b/gradientai/openapi/client/models/personalize_document_error.py
@@ -20,7 +20,7 @@ import json
 
 
 from typing import Any, Dict
-from pydantic import BaseModel, Field, constr
+from pydantic.v1 import BaseModel, Field, constr
 
 class PersonalizeDocumentError(BaseModel):
     """

--- a/gradientai/openapi/client/models/personalize_document_success.py
+++ b/gradientai/openapi/client/models/personalize_document_success.py
@@ -20,7 +20,7 @@ import json
 
 
 from typing import Any, Dict
-from pydantic import BaseModel, Field, constr
+from pydantic.v1 import BaseModel, Field, constr
 
 class PersonalizeDocumentSuccess(BaseModel):
     """

--- a/gradientai/openapi/client/models/summarize_document_body_params.py
+++ b/gradientai/openapi/client/models/summarize_document_body_params.py
@@ -20,7 +20,7 @@ import json
 
 
 from typing import Any, Dict, List, Optional
-from pydantic import BaseModel, Field, StrictStr, conlist, constr, validator
+from pydantic.v1 import BaseModel, Field, StrictStr, conlist, constr, validator
 from gradientai.openapi.client.models.summarize_document_body_params_examples_inner import SummarizeDocumentBodyParamsExamplesInner
 
 class SummarizeDocumentBodyParams(BaseModel):
@@ -68,7 +68,7 @@ class SummarizeDocumentBodyParams(BaseModel):
                             "additional_properties"
                           },
                           exclude_none=True)
-        # override the default output from pydantic by calling `to_dict()` of each item in examples (list)
+        # override the default output from pydantic.v1 by calling `to_dict()` of each item in examples (list)
         _items = []
         if self.examples:
             for _item in self.examples:

--- a/gradientai/openapi/client/models/summarize_document_body_params_examples_inner.py
+++ b/gradientai/openapi/client/models/summarize_document_body_params_examples_inner.py
@@ -20,7 +20,7 @@ import json
 
 
 from typing import Any, Dict
-from pydantic import BaseModel, Field, constr
+from pydantic.v1 import BaseModel, Field, constr
 
 class SummarizeDocumentBodyParamsExamplesInner(BaseModel):
     """

--- a/gradientai/openapi/client/models/summarize_document_error.py
+++ b/gradientai/openapi/client/models/summarize_document_error.py
@@ -20,7 +20,7 @@ import json
 
 
 from typing import Any, Dict
-from pydantic import BaseModel, Field, constr
+from pydantic.v1 import BaseModel, Field, constr
 
 class SummarizeDocumentError(BaseModel):
     """

--- a/gradientai/openapi/client/models/summarize_document_success.py
+++ b/gradientai/openapi/client/models/summarize_document_success.py
@@ -20,7 +20,7 @@ import json
 
 
 from typing import Any, Dict
-from pydantic import BaseModel, Field, constr
+from pydantic.v1 import BaseModel, Field, constr
 
 class SummarizeDocumentSuccess(BaseModel):
     """

--- a/gradientai/openapi/client/models/upload_file_error.py
+++ b/gradientai/openapi/client/models/upload_file_error.py
@@ -20,7 +20,7 @@ import json
 
 
 from typing import Any, Dict
-from pydantic import BaseModel, Field, constr
+from pydantic.v1 import BaseModel, Field, constr
 
 class UploadFileError(BaseModel):
     """

--- a/gradientai/openapi/client/models/upload_file_success.py
+++ b/gradientai/openapi/client/models/upload_file_success.py
@@ -20,7 +20,7 @@ import json
 
 
 from typing import Any, Dict
-from pydantic import BaseModel, Field, constr
+from pydantic.v1 import BaseModel, Field, constr
 
 class UploadFileSuccess(BaseModel):
     """

--- a/gradientai/pydantic_models/types.py
+++ b/gradientai/pydantic_models/types.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel
+from pydantic.v1 import BaseModel
 
 
 class CompleteResponse(BaseModel):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ version = "1.11.0"
 
 [tool.poetry.dependencies]
 aenum = ">=3.1.11"
-pydantic = "^1.10.5, <2"
+pydantic = "^2.0.0, <3"
 python = "^3.8.1"
 python-dateutil = ">=2.8.2"
 urllib3 = ">= 1.25.3"


### PR DESCRIPTION
This migrates to using Pydantic 2. There are downstream users of this package depending on modern Pydantic 2 libraries, which causes some dependency conflicts.

Fixes issue #23 
